### PR TITLE
fix: improve iteration instructions and grammar

### DIFF
--- a/docs/prompts/design.architect.gpt5.md
+++ b/docs/prompts/design.architect.gpt5.md
@@ -15,8 +15,8 @@ You produce:
 6. Compliance-first: encode data residency, backup/restore RPO/RTO, and audit expectations.
 7. Approvals-aware: include stage/prod **human validation instructions** for later promotion flows.
 8. Handoff: declare explicit dependencies on research, identity, frontend, or backend where applicable.
-9. Be willing to itterate between research and questioning to provide the best Results. Advise the operator if you need deep research enabled for a step.
-10. Self Improve: After completing the task if there are modification to the instructions or interview script that would help future itterations advise the user after providing your deliverables
+9. Be willing to iterate between research and questioning to provide the best results. Advise the operator if you need deep research enabled for a step.
+10. Self-improvement: After delivering outputs, suggest improvements to this prompt or interview script.
 
 ## Inputs You Expect
 - `research.json`, `backend.json`, `frontend.json` where available.

--- a/docs/prompts/design.backend-designer.gpt5.md
+++ b/docs/prompts/design.backend-designer.gpt5.md
@@ -13,8 +13,8 @@ You are the **Backend Designer Agent** for the APT Design phase. You collaborate
 5. Determinism: outputs must be precise,self-consistent, schema-valid, and free of ambiguity.
 6. Evidence-minded: document assumptions and open questions that downstream agents (Implementor, Architect, Identity) will need.
 7. Handoff: declare explicit dependencies on research, identity, frontend, or infra where applicable.
-8. Be willing to itterate between research and questioning to provide the best Results. Advise the operator if you need deep research enabled for a step.
-9. Self Improve: After completing the task if there are modification to the instructions or interview script that would help future itterations advise the user after providing your deliverables
+8. Be willing to iterate between research and questioning to provide the best results. Advise the operator if you need deep research enabled for a step.
+9. Self-improvement: After delivering outputs, suggest improvements to this prompt or interview script.
 
 ## Inputs You Expect
 - `research.json` from the Research Analyst Agent.

--- a/docs/prompts/design.frontend-designer.gpt5.md
+++ b/docs/prompts/design.frontend-designer.gpt5.md
@@ -15,8 +15,8 @@ You are the **Frontend Designer Agent** in the APT Design phase. You collaborate
 7. Handoff: declare explicit dependencies on research, identity, backend, or infra where applicable.
 8. Evidence-minded: document assumptions and open questions that downstream agents (Implementor, Architect, Identity) will need.
 9. Diagram-friendly: when helpful, include Mermaid snippets for user flows and wireframes in the **human doc** (never in the JSON).
-10. Be willing to itterate between research and questioning to provide the best Results. Advise the operator if you need deep research enabled for a step.
-11. Self Improve: After completing the task if there are modification to the instructions or interview script that would help future itterations advise the user after providing your deliverables
+10. Be willing to iterate between research and questioning to provide the best results. Advise the operator if you need deep research enabled for a step.
+11. Self-improvement: After delivering outputs, suggest improvements to this prompt or interview script.
 
 ## Inputs You Expect
 - `research.json` and any PRD/requirements supplied earlier.

--- a/docs/prompts/design.research-analyst.gpt5.md
+++ b/docs/prompts/design.research-analyst.gpt5.md
@@ -7,14 +7,14 @@ You are the **Product Research Analyst Agent** for the APT Design phase. You int
 3) You are working out of Repo : 
 
 ## Operating Principles
-1. Be willing to itterate between research and questioning to provide the best Results.  Advise the operator if you need deep research enabled for a step.
+1. Be willing to iterate between research and questioning to provide the best results. Advise the operator if you need deep research enabled for a step.
 2. Dual audience: write clearly for stakeholders **and** emit strict JSON for automation.
 3. Numbered questioning: use questions 1.x, 1.x.x to gather missing data.
 4. Evidence-minded: prefer cited, checkable facts where possible (links, data sources).
 5. Determinism: the JSON must be self-consistent, unambiguous, and schema-valid.
 6. Scope discipline: do not drift into technical design (owned by Backend/Frontend/Architect/Identity/Data Flow agents).
 7. Handoff awareness: include crisp “assumptions & open questions” so downstream agents can proceed or request clarification.
-8. Self Improve: After completing the task if there are modification to the instructions or interview script that would help future itterations advise the user after providing your deliverables
+8. Self-improvement: After delivering outputs, suggest improvements to this prompt or interview script.
 
 ## Inputs You Expect
 - Project or feature name and summary.


### PR DESCRIPTION
## Summary
- Use correct "iterate" spelling across design agent prompts
- Clarify self-improvement guidance to request feedback on the prompt or interview script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2efae29bc833289d775527572aad2