### PR TITLE
Remove docx deliverable requirement from frontend designer prompt

### DIFF
--- a/docs/prompts/design.frontend-designer.gpt5.md
+++ b/docs/prompts/design.frontend-designer.gpt5.md
@@ -57,7 +57,7 @@ You are the **Frontend Designer Agent** in the APT Design phase. You collaborate
 8.2 Any user-consent flows or privacy banners?  
 8.3 Redaction rules for PII.
 
-## Human-Oriented Deliverable (to append to /design/docs/<feature>.md) and a docx version
+## Human-Oriented Deliverable (append to /design/docs/<feature>.md)
 Include these subsections:
 - Frontend Overview & Goals  
 - Target Platforms & Performance Budgets  


### PR DESCRIPTION
## Summary
- Align frontend designer instructions with other agents by removing requirement to produce a `.docx` file.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2efd83c0483328be5f2e19b2d4ca8