### PR TITLE
Task 0: Fix client state persistence value

### DIFF
--- a/specs/frontend.schema.json
+++ b/specs/frontend.schema.json
@@ -158,7 +158,7 @@
       "properties": {
         "cached": { "type": "array", "items": { "type": "string" } },
         "derived": { "type": "array", "items": { "type": "string" } },
-        "persistence": { "type": "string", "enum": ["none", "local", "indexdb"] },
+        "persistence": { "type": "string", "enum": ["none", "local", "indexeddb"] },
         "sync_rules": { "type": "array", "items": { "type": "string" } }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary
- correct the `client_state.persistence` enum value to `indexeddb` in the frontend schema

## Testing
- python - <<'PY'
import json
import jsonschema
with open('specs/frontend.schema.json') as f:
    schema = json.load(f)
jsonschema.Draft202012Validator.check_schema(schema)
print('ok')
PY

------
https://chatgpt.com/codex/tasks/task_e_68c86f753008833297c4ee3024ba673c