### PR TITLE
Add pattern validation to research schema feature_id

### DIFF
--- a/specs/research.schema.json
+++ b/specs/research.schema.json
@@ -22,7 +22,8 @@
   "properties": {
     "feature_id": {
       "type": "string",
-      "description": "Unique slug for the feature/product being researched"
+      "description": "Unique slug for the feature/product being researched",
+      "pattern": "^[a-z0-9][a-z0-9-]{1,63}$"
     },
     "version": { "type": "string" },
     "created_at": { "type": "string", "format": "date-time" },


### PR DESCRIPTION
## Summary
- add the standard slug regex pattern to the `feature_id` field in the research schema to match other specs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c86f9b5b2883328846563a47f74b38