### PR TITLE
Add HEAD and OPTIONS to internal API methods schema

### DIFF
--- a/specs/backend.schema.json
+++ b/specs/backend.schema.json
@@ -52,7 +52,7 @@
               "name": { "type": "string" },
               "methods": {
                 "type": "array",
-                "items": { "type": "string", "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"] }
+                "items": { "type": "string", "enum": ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"] }
               },
               "payload_examples": { "type": "object", "additionalProperties": true },
               "sla": { "type": "string" }


### PR DESCRIPTION
## Summary
- allow internal API method definitions to include HEAD and OPTIONS in the backend schema

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c86fa3a9dc8332979e9d9ff5e29e00