### PR TITLE
Add application lifecycle bundle schema and samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,11 +855,17 @@ This section shows how to go from a raw feature idea to production using AI Dev 
 **Result:** Artifact safely promoted through dev → test → stage → prod.
 
 ### Step 7 — Audit and Snapshot
-- Runtime artifacts live under `/state/` while runs are active.  
-- Run `/scripts/gc-runs.mjs` to prune old states once complete.  
+- Runtime artifacts live under `/state/` while runs are active.
+- Run `/scripts/gc-runs.mjs` to prune old states once complete.
 - Commit durable snapshots into `/docs/runs/<feature>/` for audit.
 
 **Result:** Clean repo state and permanent audit trail.
+
+### Application Lifecycle Bundles
+- `specs/application.schema.json` defines the canonical top-level bundle that stitches together design, integration, release, and operations artifacts for a feature run.
+- The schema references `design.schema.json`, `ReturnEnvelope.schema.json`, `review.schema.json`, `handoff-event.schema.json`, `ReleasePlan.schema.json`, `DeployEnvelope.schema.json`, `DBChangeEnvelope.schema.json`, and `TestReport.schema.json` so orchestration can validate the complete story end-to-end.
+- Sample bundles live in `docs/samples/application-lifecycle.example.json` (full run) and `docs/samples/application-lifecycle.minimal.json` (skeleton payload).
+- Validate any generated bundle with your preferred JSON Schema tool, e.g. `python -m jsonschema -i docs/samples/application-lifecycle.example.json specs/application.schema.json` after installing the `jsonschema` package.
 
 ---
 

--- a/docs/samples/application-lifecycle.example.json
+++ b/docs/samples/application-lifecycle.example.json
@@ -1,0 +1,209 @@
+{
+  "application_id": "sample-feature",
+  "version": "1.0.0",
+  "assembled_at": "2024-05-01T12:00:00Z",
+  "description": "End-to-end lifecycle bundle used for documentation and validation examples.",
+  "links": [
+    "https://status.example.com/sample-feature"
+  ],
+  "design": {
+    "assembled_at": "2024-04-30T15:30:00Z",
+    "research": null,
+    "backend": null,
+    "frontend": null,
+    "identity": null,
+    "architecture": null,
+    "dataflow": null,
+    "plan": null,
+    "dependencies": null
+  },
+  "integration": {
+    "return_envelopes": [
+      {
+        "task_id": "task-001",
+        "summary": "Implement feature skeleton",
+        "patch_strategy": "atomic",
+        "changes": [
+          {
+            "path": "src/app.js",
+            "action": "modify",
+            "before_sha256": "prev-sha",
+            "after_sha256": "next-sha",
+            "patch": "---sample diff---"
+          }
+        ],
+        "run_checks": [
+          "npm test"
+        ],
+        "notes": "Initial implementation of the feature skeleton.",
+        "budget_report": {
+          "calls_used": 3,
+          "usd_estimate": 0.45,
+          "within_budget": true
+        },
+        "no_op": false
+      }
+    ],
+    "reviews": [
+      {
+        "task_id": "task-001",
+        "verdict": "pass",
+        "errors": [],
+        "retry_suggested": false,
+        "escalate": false,
+        "logs": [
+          "All acceptance criteria satisfied."
+        ]
+      }
+    ],
+    "handoff_events": [
+      {
+        "event": "agent_completed",
+        "agent": "implementor",
+        "feature_id": "sample-feature",
+        "artifact": "/design/plan.json",
+        "sha": "abc123",
+        "ts": "2024-04-30T15:45:00Z"
+      }
+    ]
+  },
+  "release": {
+    "plan": {
+      "release_id": "sample-release",
+      "version": "2024.05.01",
+      "created_at": "2024-04-29T09:00:00Z",
+      "environments": [
+        {
+          "name": "dev",
+          "strategy": "rolling",
+          "hold_for_approval": false,
+          "tests": [
+            "unit",
+            "integration"
+          ],
+          "health": {
+            "checks": [
+              "curl https://sample-dev.internal/health"
+            ],
+            "error_budget_minutes": 15
+          },
+          "db_changes": [
+            "db-migration-001"
+          ]
+        },
+        {
+          "name": "prod",
+          "strategy": "blue_green",
+          "hold_for_approval": true,
+          "tests": [
+            "smoke"
+          ],
+          "health": {
+            "checks": [
+              "curl https://sample-prod.internal/health"
+            ],
+            "error_budget_minutes": 5
+          },
+          "db_changes": []
+        }
+      ]
+    },
+    "status": "in_progress",
+    "approved_by": "Product Lead"
+  },
+  "operations": {
+    "deployments": [
+      {
+        "env": "dev",
+        "strategy": "rolling",
+        "commands": [
+          "helm upgrade sample-app ./charts/sample-app --namespace dev"
+        ],
+        "health_checks": [
+          "curl https://sample-dev.internal/health"
+        ],
+        "rollback": {
+          "commands": [
+            "helm rollback sample-app"
+          ],
+          "verification": [
+            "curl https://sample-dev.internal/health"
+          ]
+        },
+        "notes": "Deployed build 1.0.0 to dev."
+      },
+      {
+        "env": "prod",
+        "strategy": "blue_green",
+        "commands": [
+          "helm upgrade sample-app ./charts/sample-app --namespace prod"
+        ],
+        "health_checks": [
+          "curl https://sample-prod.internal/health"
+        ],
+        "rollback": {
+          "commands": [
+            "helm rollback sample-app"
+          ],
+          "verification": [
+            "curl https://sample-prod.internal/health"
+          ]
+        },
+        "notes": "Staged blue/green cutover prepared."
+      }
+    ],
+    "db_changes": [
+      {
+        "env": "dev",
+        "before_version": "2024.04.20",
+        "after_version": "2024.04.30",
+        "backup": {
+          "location": "s3://backups/sample-feature/dev/2024-04-30.sql",
+          "created_at": "2024-04-30T10:00:00Z",
+          "verified": true
+        },
+        "migrations": [
+          {
+            "id": "001-add-table",
+            "description": "Create table for new feature",
+            "status": "applied",
+            "logs": "Applied successfully"
+          }
+        ],
+        "rollback": {
+          "commands": [
+            "psql -f rollback/001.sql"
+          ],
+          "verification": [
+            "SELECT COUNT(*) FROM new_table;"
+          ]
+        },
+        "notes": "No issues during dev migration."
+      }
+    ],
+    "test_reports": [
+      {
+        "env": "dev",
+        "suite": "integration",
+        "command": "npm run test:integration",
+        "status": "passed",
+        "stats": {
+          "passed": 120,
+          "failed": 0,
+          "skipped": 2
+        },
+        "logs": [
+          "All integration tests passed."
+        ],
+        "artifacts": [
+          "s3://artifacts/sample-feature/dev/integration-report.html"
+        ]
+      }
+    ],
+    "notes": "Promotion to dev succeeded; prod queued for approval.",
+    "incidents": []
+  },
+  "attachments": [
+    "docs/runs/sample-feature/summary.md"
+  ]
+}

--- a/docs/samples/application-lifecycle.minimal.json
+++ b/docs/samples/application-lifecycle.minimal.json
@@ -1,0 +1,20 @@
+{
+  "application_id": "minimal-bundle",
+  "version": "2024.05.01",
+  "assembled_at": "2024-05-02T08:00:00Z",
+  "description": "Skeleton bundle demonstrating the minimal shape required by application.schema.json.",
+  "design": null,
+  "integration": {
+    "return_envelopes": []
+  },
+  "release": {
+    "plan": null,
+    "status": "draft"
+  },
+  "operations": {
+    "deployments": [],
+    "db_changes": [],
+    "test_reports": [],
+    "notes": "Awaiting deployment kick-off."
+  }
+}

--- a/specs/application.schema.json
+++ b/specs/application.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "title": "Application Lifecycle Bundle",
+  "description": "Normalized package of design, integration, release, and operations artifacts for a single application or feature run.",
+  "type": "object",
+  "required": [
+    "application_id",
+    "version",
+    "assembled_at",
+    "design",
+    "integration",
+    "release",
+    "operations"
+  ],
+  "properties": {
+    "application_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{1,63}$",
+      "description": "Unique identifier for the application or feature."
+    },
+    "version": {
+      "type": "string",
+      "description": "Semantic or monotonic version for this assembled bundle."
+    },
+    "assembled_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the lifecycle bundle was produced."
+    },
+    "description": {
+      "type": "string",
+      "description": "Optional human-readable summary for the bundle."
+    },
+    "links": {
+      "type": "array",
+      "description": "Optional references to dashboards, documents, or pipelines relevant to the bundle.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "design": {
+      "description": "Design-phase artifact bundle for the application run.",
+      "anyOf": [
+        { "$ref": "./design.schema.json" },
+        { "type": "null" }
+      ]
+    },
+    "integration": {
+      "type": "object",
+      "description": "Integration phase outputs and audit trail.",
+      "required": ["return_envelopes"],
+      "properties": {
+        "return_envelopes": {
+          "type": "array",
+          "items": { "$ref": "./ReturnEnvelope.schema.json" },
+          "description": "Chronological list of implementor deliveries applied to the codebase."
+        },
+        "reviews": {
+          "type": "array",
+          "items": { "$ref": "./review.schema.json" },
+          "description": "Reviewer verdicts associated with the return envelopes."
+        },
+        "handoff_events": {
+          "type": "array",
+          "items": { "$ref": "./handoff-event.schema.json" },
+          "description": "Detailed orchestration handoff events captured during integration."
+        }
+      },
+      "additionalProperties": false
+    },
+    "release": {
+      "type": "object",
+      "description": "Release governance metadata for the bundle.",
+      "required": ["plan"],
+      "properties": {
+        "plan": {
+          "description": "Release plan approved for deployment.",
+          "anyOf": [
+            { "$ref": "./ReleasePlan.schema.json" },
+            { "type": "null" }
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": ["draft", "approved", "in_progress", "complete", "halted"],
+          "description": "Lifecycle state of the release."
+        },
+        "approved_by": {
+          "type": "string",
+          "description": "Optional approver or authority for the release."
+        }
+      },
+      "additionalProperties": false
+    },
+    "operations": {
+      "type": "object",
+      "description": "Operational artifacts produced while executing the release.",
+      "required": ["deployments", "db_changes", "test_reports"],
+      "properties": {
+        "deployments": {
+          "type": "array",
+          "items": { "$ref": "./DeployEnvelope.schema.json" },
+          "description": "Deploy envelopes produced per environment."
+        },
+        "db_changes": {
+          "type": "array",
+          "items": { "$ref": "./DBChangeEnvelope.schema.json" },
+          "description": "Database change envelopes tied to the release."
+        },
+        "test_reports": {
+          "type": "array",
+          "items": { "$ref": "./TestReport.schema.json" },
+          "description": "Verification reports from executed test suites."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Operational summary, incidents, or follow-up actions."
+        },
+        "incidents": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Incident identifiers or links captured during operations."
+        }
+      },
+      "additionalProperties": false
+    },
+    "attachments": {
+      "type": "array",
+      "description": "Supporting documents committed alongside the bundle.",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add an application lifecycle bundle schema that links design, integration, release, and operations artifacts for a single run
- provide full and minimal sample bundles that validate against the new schema
- document the bundle location and validation guidance in the README

## Testing
- python - <<'PY'
import json
import pathlib
from jsonschema import Draft202012Validator, RefResolver

schema_path = pathlib.Path('specs/application.schema.json').resolve()
schema = json.loads(schema_path.read_text())
resolver = RefResolver(base_uri=schema_path.as_uri(), referrer=schema)
validator = Draft202012Validator(schema, resolver=resolver)

for sample in [
    'docs/samples/application-lifecycle.example.json',
    'docs/samples/application-lifecycle.minimal.json'
]:
    instance = json.loads(pathlib.Path(sample).read_text())
    validator.validate(instance)
    print(f"{sample}: OK")
PY

------
https://chatgpt.com/codex/tasks/task_e_68c875c1b2608332b5e410001cb5d270