### PR TITLE
Add PRD schema and template

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,12 +399,15 @@ This makes the process predictable, auditable, and easy to resume.
 - **`/docs/planning/`** — Prompt templates and guides for design  
   - `TEAM.chat.md`, individual module prompts, planner prompt, dependencies prompt, `USAGE-n8n.md`.  
 
-- **`/docs/cd/`** — Prompt templates and guides for deployment  
-  - Prompts for CD Manager, Deployer, DBA, Tester, SRE Reviewer.  
-  - `USAGE-CD.md` → guide to set up n8n CD workflow.  
+- **`/docs/cd/`** — Prompt templates and guides for deployment
+  - Prompts for CD Manager, Deployer, DBA, Tester, SRE Reviewer.
+  - `USAGE-CD.md` → guide to set up n8n CD workflow.
 
-- **`/tools/`** — Orchestrator-side scripts and helpers  
-  - `repo-snapshot.mjs`, `apply-envelope.mjs`, `deploy.mjs`, `run-tests.mjs`, `healthcheck.mjs`, `backup-db.mjs`, `migrate-db.mjs`.  
+- **`/docs/templates/`** — Ready-to-use document templates for stakeholders.
+  - `design.doc.md` and `prd.md` align human narratives with the JSON schemas used by automation.
+
+- **`/tools/`** — Orchestrator-side scripts and helpers
+  - `repo-snapshot.mjs`, `apply-envelope.mjs`, `deploy.mjs`, `run-tests.mjs`, `healthcheck.mjs`, `backup-db.mjs`, `migrate-db.mjs`.
 
 - **`/.github/workflows/`** — CI definitions  
   - `validate-schemas.yml` → validate design and plan files.  
@@ -423,12 +426,14 @@ This keeps the workflow predictable, auditable, and safe for automation.
 
 ### Core Contracts
 
-- **PRD (`/specs/Prd.schema.json`)**  
-  Defines the structure of a Product Requirements Document in JSON.  
-  • Title, goals, non-functional requirements.  
-  • Functional requirements with acceptance criteria.  
-  • Risks, assumptions, and release slices.  
-  • Basis for both stakeholder docs and the Planner’s task DAG.
+- **PRD (`/specs/Prd.schema.json`)**
+  Defines the structure of a Product Requirements Document in JSON.
+  • Title plus the narrative context for the initiative.
+  • Goals with success metrics and prioritization.
+  • Requirements with category, priority, and goal links.
+  • Acceptance criteria mapped to each requirement.
+  • Risks with mitigation ownership and status.
+  • Human-readable companion template: `/docs/templates/prd.md`.
 
 - **Plan (`/specs/Plan.schema.json`)**  
   Represents the execution plan (task DAG).  

--- a/docs/templates/prd.md
+++ b/docs/templates/prd.md
@@ -1,0 +1,50 @@
+# Product Requirements Document
+
+Use this template to capture the human-facing narrative that pairs with the structured PRD schema (`/specs/Prd.schema.json`). Replace the bracketed guidance with project-specific details.
+
+## Title
+> Example: "Unified Billing Portal – Phase 1"
+
+## Overview
+Provide a concise summary of the problem, audience, and the opportunity. Mention the sponsoring team and any key partners.
+
+## Goals
+| Goal ID | Statement | Success Metric | Target | Priority |
+| ------- | --------- | -------------- | ------ | -------- |
+| GOAL-1  |           |                |        | Primary  |
+
+## Non-Goals
+List the items that are explicitly out of scope for this iteration so downstream teams can de-prioritize them.
+
+## Requirements
+| Requirement ID | Description | Category | Priority | Supports Goals | Notes |
+| -------------- | ----------- | -------- | -------- | -------------- | ----- |
+| REQ-1          |             |          | Must Have | GOAL-1         |       |
+
+## Acceptance Criteria
+| Criterion ID | Requirement | Criteria | Verification Method | Owner |
+| ------------ | ----------- | -------- | ------------------- | ----- |
+| AC-1         | REQ-1       |          | Automated Test      |       |
+
+## User Experience Notes
+Capture wireframe links, accessibility considerations, or UX guidelines that should accompany the requirements.
+
+## Analytics & Telemetry
+Document any tracking events, dashboards, or success metrics instrumentation that must be available at launch.
+
+## Risks & Mitigations
+| Risk ID | Description | Likelihood | Impact | Mitigation | Owner | Status |
+| ------- | ----------- | ---------- | ------ | ---------- | ----- | ------ |
+| RISK-1  |             | Medium     | High   |            |       | Open   |
+
+## Open Questions
+List outstanding questions that need resolution before implementation can start.
+
+## Dependencies & Assumptions
+Record tooling, data, or staffing dependencies, plus any assumptions you are making that affect the plan.
+
+## Launch Considerations
+Outline rollout strategy, success metrics monitoring, and any training or documentation needs for launch.
+
+## Appendix
+Add supporting research, references, or links to related specs.

--- a/specs/Prd.schema.json
+++ b/specs/Prd.schema.json
@@ -1,0 +1,242 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "title": "Product Requirements Document",
+  "description": "Schema for the structured PRD artifact that captures goals, requirements, acceptance criteria, and risks.",
+  "type": "object",
+  "required": [
+    "title",
+    "goals",
+    "requirements",
+    "acceptance",
+    "risks"
+  ],
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human readable title for the product requirements document."
+    },
+    "goals": {
+      "type": "array",
+      "description": "Strategic or customer outcomes the PRD is intended to accomplish.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "statement"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_-]{1,32}$",
+            "description": "Stable identifier for referencing this goal in downstream planning artifacts."
+          },
+          "statement": {
+            "type": "string",
+            "description": "Short description of the desired outcome or customer benefit."
+          },
+          "metric": {
+            "type": "string",
+            "description": "How success for this goal will be measured."
+          },
+          "target": {
+            "type": "string",
+            "description": "Quantitative or qualitative target associated with the metric."
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "primary",
+              "secondary",
+              "optional"
+            ],
+            "description": "Relative importance of the goal."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "requirements": {
+      "type": "array",
+      "description": "Functional and non-functional requirements necessary to satisfy the goals.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "description",
+          "category",
+          "priority"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_-]{1,32}$",
+            "description": "Stable identifier for the requirement (used by acceptance criteria and planning)."
+          },
+          "description": {
+            "type": "string",
+            "description": "Narrative description of the capability or constraint."
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "functional",
+              "non_functional",
+              "constraint",
+              "compliance",
+              "ux",
+              "analytics",
+              "other"
+            ],
+            "description": "Classification that indicates the nature of the requirement."
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "must_have",
+              "should_have",
+              "could_have",
+              "wont_have"
+            ],
+            "description": "Priority using the MoSCoW scale."
+          },
+          "goal_links": {
+            "type": "array",
+            "description": "Goal identifiers that this requirement supports.",
+            "items": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9_-]{1,32}$"
+            }
+          },
+          "rationale": {
+            "type": "string",
+            "description": "Context explaining why the requirement exists."
+          },
+          "notes": {
+            "type": "string",
+            "description": "Additional considerations such as design direction or sequencing guidance."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "acceptance": {
+      "type": "array",
+      "description": "Acceptance criteria that confirm a requirement has been met.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "requirement_id",
+          "criteria"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_-]{1,32}$",
+            "description": "Unique identifier for the acceptance criterion."
+          },
+          "requirement_id": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_-]{1,32}$",
+            "description": "Identifier of the requirement that this criterion verifies."
+          },
+          "criteria": {
+            "type": "string",
+            "description": "Clear, testable statement of how to verify the requirement is satisfied."
+          },
+          "verification": {
+            "type": "string",
+            "enum": [
+              "manual",
+              "automated",
+              "analysis",
+              "demo",
+              "other"
+            ],
+            "description": "Primary method used to confirm the criterion."
+          },
+          "owner": {
+            "type": "string",
+            "description": "Person or role accountable for validating the criterion."
+          },
+          "notes": {
+            "type": "string",
+            "description": "Additional guidance or links to supporting evidence."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "risks": {
+      "type": "array",
+      "description": "Risks that could block delivery or reduce the value of the PRD.",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "description",
+          "likelihood",
+          "impact"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_-]{1,32}$",
+            "description": "Stable identifier for tracking the risk."
+          },
+          "description": {
+            "type": "string",
+            "description": "Summary of the risk condition."
+          },
+          "likelihood": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "description": "Probability of the risk materializing."
+          },
+          "impact": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ],
+            "description": "Severity of the risk if it occurs."
+          },
+          "mitigation": {
+            "type": "string",
+            "description": "Plan to reduce likelihood or impact."
+          },
+          "owner": {
+            "type": "string",
+            "description": "Person or team responsible for managing the risk."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "open",
+              "mitigating",
+              "closed",
+              "accepted"
+            ],
+            "description": "Current tracking status."
+          },
+          "notes": {
+            "type": "string",
+            "description": "Additional context or related follow-ups."
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add a Product Requirements Document schema covering title, goals, requirements, acceptance criteria, and risks
- add a human-readable PRD template aligned with the schema
- document the new schema and template locations in the README

## Testing
- jq empty specs/Prd.schema.json

------
https://chatgpt.com/codex/tasks/task_e_68c880066edc8332bc5b79920c8a25c9