### PR TITLE
Task 0: Clarify orchestrators and prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 | Path | Responsibilities |
 | --- | --- |
 | `docs/prompts/` | Prompt templates for design, planning, integration, and CD agents. Update these after copying the repo. |
+| `/research/` | Raw research artifacts (transcripts, notes, source dumps) captured before synthesis into design docs. |
 | `design/` | Human design docs (`docs/<feature>.md`), machine artifacts (`*.json`), and planning files like `plan.json` and `dependencies.json`. |
 | `specs/` | JSON schemas that every artifact must validate against. |
 | `cd/` | Deployment plans (`release.json`). |
@@ -38,4 +39,4 @@ A feature branch with one commit per task and green CI, accompanied by validated
 
 ## 8. References
 - `README.md` – detailed workflow guide and FAQ.
-- `product-manager-agent*.gpt5.md` – operating principles for the Product Manager agent.
+- [`docs/prompts/product-manager-agent.gpt5.md`](docs/prompts/product-manager-agent.gpt5.md) – operating principles for the Product Manager agent.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - `design/` - human design docs and machine artifacts
 - `research/` - raw research transcripts, notes, and evidence captured before synthesis
 - `cd/` - deployment plans
+- `docs/prompts/` - orchestrator prompts for codex and n8n agents, including the [Product Manager kickoff brief](docs/prompts/product-manager-agent.gpt5.md)
 - `docs/runs/` - audit snapshots of completed runs
 - `state/` - runtime state (gitignored)
 
@@ -394,37 +395,35 @@ This makes the process predictable, auditable, and easy to resume.
 
 ### Top-Level Directories
 
-- **`/design/`** — Design & dependency phase outputs  
-  - `/design/docs/<feature>.md` → human-readable design document (narrative spec, approved by stakeholders).  
-  - `/design/*.json` → machine-readable artifacts (research, backend, frontend, architecture, identity, dataflow, plan, dependencies).  
+- **`/design/`** — Design & dependency phase outputs
+  - `/design/docs/<feature>.md` → human-readable design document (narrative spec, approved by stakeholders).
+  - `/design/*.json` → machine-readable artifacts (research, backend, frontend, architecture, identity, dataflow, plan, dependencies).
 
-- **`/specs/`** — JSON Schemas used to validate agent outputs.  
-  - **Key files:**  
-    - `Plan.schema.json` — structure of the execution DAG.  
-    - `ReturnEnvelope.schema.json` — structure of Implementor outputs.  
-    - `ReleasePlan.schema.json` — environment promotion plan.  
+- **`/research/`** — Source interviews, transcripts, and market notes captured before synthesis.
+
+- **`/specs/`** — JSON Schemas used to validate agent outputs.
+  - **Key files:**
+    - `Plan.schema.json` — structure of the execution DAG.
+    - `ReturnEnvelope.schema.json` — structure of Implementor outputs.
+    - `ReleasePlan.schema.json` — environment promotion plan.
   - Additional schemas cover design modules (research, backend, frontend, identity, dataflow, dependencies, etc.).
 
-- **`/state/`** — Runtime state (gitignored; not checked in)  
-  - `/state/runs/<run-id>/task-<id>.json` → ReturnEnvelopes from integration.  
-  - `/state/cd/<run-id>/<env>/...` → Deployment artifacts: DeployEnvelope, DBChangeEnvelope, TestReports, logs.  
+- **`/cd/`** — Deployment planning inputs
+  - `/cd/release.json` → ReleasePlan describing environments, strategies, health budgets, test suites, DB changes.
 
-- **`/cd/`** — Deployment planning inputs  
-  - `/cd/release.json` → ReleasePlan describing environments, strategies, health budgets, test suites, DB changes.  
+- **`/docs/prompts/`** — Prompt templates for codex and n8n agents (Product Manager kickoff, research, design, integration, CD).
 
-- **`/docs/planning/`** — Prompt templates and guides for design  
-  - `TEAM.chat.md`, individual module prompts, planner prompt, dependencies prompt, `USAGE-n8n.md`.  
+- **`/docs/templates/`** — Run templates and governance checklists for humans.
 
-- **`/docs/cd/`** — Prompt templates and guides for deployment  
-  - Prompts for CD Manager, Deployer, DBA, Tester, SRE Reviewer.  
-  - `USAGE-CD.md` → guide to set up n8n CD workflow.  
+- **`/docs/runs/`** — Durable audit snapshots captured after each automation run.
 
-- **`/tools/`** — Orchestrator-side scripts and helpers  
-  - `repo-snapshot.mjs`, `apply-envelope.mjs`, `deploy.mjs`, `run-tests.mjs`, `healthcheck.mjs`, `backup-db.mjs`, `migrate-db.mjs`.  
+- **`/docs/samples/`** — Example artifacts illustrating schema-compliant outputs.
 
-- **`/.github/workflows/`** — CI definitions  
-  - `validate-schemas.yml` → validate design and plan files.  
-  - Additional workflows for lint, tests, build (project-specific).  
+- **`/scripts/`** — Orchestrator helpers for applying envelopes, running tests, and garbage collection.
+
+- **`/state/`** — Runtime state (gitignored; not checked in)
+  - `/state/runs/<run-id>/task-<id>.json` → ReturnEnvelopes from integration.
+  - `/state/cd/<run-id>/<env>/...` → Deployment artifacts: DeployEnvelope, DBChangeEnvelope, TestReports, logs.
 
 ### Lifecycle Mapping
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,22 @@
 ### Repository Structure
 
 - `design/` - human design docs and machine artifacts
+- `research/` - raw research transcripts, notes, and evidence captured before synthesis
 - `cd/` - deployment plans
 - `docs/runs/` - audit snapshots of completed runs
 - `state/` - runtime state (gitignored)
+
+### Orchestrators & Agent Placement
+
+Two orchestrators collaborate throughout the workflow:
+
+- **codex** hosts the conversational discovery agents: Product Manager, Research Analyst, Backend Designer, Frontend Designer, Identity Designer, Architect, Data Flow, and Planner. These agents interview stakeholders, refine scope, and produce design artifacts before implementation starts.
+- **n8n** runs the deterministic automation loops: Docs Assembler, Design Reviewer, Integration Manager, Implementor, Reviewer, and the CD suite (Manager, Deployer, DBA, Tester, SRE Reviewer). n8n applies file diffs, executes CI/CD, and persists run state.
+
+| Orchestrator | Agents |
+| --- | --- |
+| codex | Product Manager, Research Analyst, Backend Designer, Frontend Designer, Identity Designer, Architect, Data Flow, Planner |
+| n8n | Docs Assembler, Design Reviewer, Integration Manager, Implementor, Reviewer, CD Manager, CD Deployer, DBA, Tester, SRE Reviewer |
 
 **AI Dev Tasks** is a schema-first, orchestrator-driven framework that turns a feature idea into deployed code through four phases:
 
@@ -16,7 +29,10 @@
      - **Human-oriented spec sections** → appended to `/design/docs/<feature>.md` for stakeholders.  
      - **Machine-oriented artifacts** → `/design/*.json`, validated against `/specs/*.schema.json`, for automation.  
    - **Agents and responsibilities:**
-     - **Research Analyst Agent** → *Product Research & Prospectus*: market, competitors, TAM/SAM/SOM, pricing, **cost-to-deliver**, **margin projections**.  
+    - **Product Manager Agent** → *Product Brief & Success Metrics*: executive summary, personas, success metrics, release guardrails, and in/out-of-scope notes to anchor the run.
+       - Human: executive summary and personas/JTBD sections appended to `/design/docs/<feature>.md`.
+       - AI: structured kickoff brief shared inside codex for downstream agents.
+    - **Research Analyst Agent** → *Product Research & Prospectus*: market, competitors, TAM/SAM/SOM, pricing, **cost-to-deliver**, **margin projections**.
        - Human: prospectus narrative.  
        - AI: `research.json`.  
      - **Backend Designer Agent** → *Backend Design*: processing flows, data models, APIs, storage/scaling trade-offs.  

--- a/docs/prompts/product-manager-agent.gpt5.md
+++ b/docs/prompts/product-manager-agent.gpt5.md
@@ -1,0 +1,58 @@
+# Product Manager Agent — GPT-5 (codex orchestration)
+
+## Role
+You are the **Product Manager Agent** who kicks off every APT run inside the codex orchestrator. Your job is to translate the raw feature request into a crisp opportunity brief that downstream design and implementation agents can execute without ambiguity.
+
+## Operating Principles
+1. **Business-first framing:** anchor every decision to the customer problem, target persona, and measurable impact.
+2. **Codex collaboration:** maintain numbered dialogue that codex can replay for future agents; summarize clarifications before moving on.
+3. **Scope discipline:** capture what is explicitly in/out for the first release, and flag stretch ideas separately.
+4. **Metric-driven success:** define quantifiable success metrics plus guardrails (adoption, quality, financial, operational).
+5. **Handoff readiness:** package insights so Research, Design, Planner, and Integration agents can consume them without another interview.
+6. **Evidence awareness:** reference any existing research stored under `/research/` so later agents can cite the source of truth.
+7. **Iterative refinement:** propose prompt or workflow improvements after each run to improve future codex sessions.
+
+## Inputs You Expect
+- Feature or product name and repository link.
+- Problem statement, user personas, and target market.
+- Business goals (revenue, retention, compliance) and guardrails.
+- Known launch deadlines, release constraints, or budget ceilings.
+- References to prior research artifacts (filenames under `/research/`).
+
+## Interview Script (use, adapt, prune)
+1. **Context & Goals**
+   1.1 What triggered this feature now?
+   1.2 Which personas benefit first? secondary personas?
+   1.3 How will leadership judge success in the first 90 days?
+2. **User & Market Truths**
+   2.1 What evidence already exists (pilots, surveys, `/research/` assets)?
+   2.2 Biggest pains or unmet needs you have validated?
+   2.3 Competitive or alternative solutions we must beat?
+3. **Scope & Release Strategy**
+   3.1 Must-have capabilities for the first launch?
+   3.2 Out-of-scope or explicitly deferred ideas?
+   3.3 Release sequencing assumptions (beta → GA, region rollouts)?
+4. **Operational & Compliance Guardrails**
+   4.1 SLAs, legal, or regulatory requirements?
+   4.2 Budget, staffing, or integration constraints?
+   4.3 External reviews/approvals required before launch?
+5. **Success Metrics & Follow-up**
+   5.1 Primary adoption/usage metric with target value?
+   5.2 Quality or risk guardrails (e.g., churn, incident budget)?
+   5.3 Open questions requiring follow-up research?
+
+## Outputs You Produce
+- **Markdown sections** for `/design/docs/<feature>.md` covering `Executive Summary` and `Personas & Jobs-to-Be-Done` with clear owners, timelines, and rationale.
+- **Structured kickoff brief** summarizing success metrics, in-scope/out-of-scope items, dependencies to investigate, and open questions for downstream agents.
+- **Prompt improvements** suggestions after delivering outputs.
+
+## Output Protocol
+When the requester says **“Finalize”**, respond with the following blocks in order:
+1. Markdown headed sections ready to paste into `/design/docs/<feature>.md`.
+2. JSON object `{ "success_metrics": [...], "in_scope": [...], "out_of_scope": [...], "dependencies_to_validate": [...], "open_questions": [...] }`.
+3. *(Optional)* JSON array of prompt or workflow improvement suggestions.
+
+## Coordination Notes
+- Share the structured kickoff brief with the Research Analyst and Planner agents inside codex so they inherit goals and constraints.
+- Surface any newly cited evidence into `/research/` if it is not already recorded (coordinate with humans to upload documents).
+- Escalate to a human owner if the request conflicts with stated goals, budget, or compliance limits.

--- a/research/.gitkeep
+++ b/research/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep the research artifact directory under version control.


### PR DESCRIPTION
## Summary
- note `/research/` as the home for raw research artifacts in the directory table
- add the missing Product Manager agent prompt and link to it from the blueprint docs
- document which agents run in codex versus n8n, including the Product Manager’s role in the design phase

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c8800bca508332ad344a313ca6f900