### PR TITLE
Update planner prompt for Codex task export

### DIFF
--- a/docs/prompts/design.planner.gpt5.md
+++ b/docs/prompts/design.planner.gpt5.md
@@ -20,6 +20,7 @@ You are the **Planner Agent**. You consume prior Design outputs and produce a de
 5. Set **model routing and budgets** per task (override defaults only when needed).
 6. Lift **stage/prod human validation steps** from design artifacts into approvals.
 7. Emit a **Dependency Prep Checklist** of human actions required prior to Integration, and a machine-readable `dependencies.json` for CI gating (Phase 1.5).
+8. Surface a Codex-friendly view of every task containing `title`, `context`, and `files` metadata for downstream automation.
 
 ## Numbered Planning Script (use, adapt, prune)
 1. Scope & prerequisites  
@@ -30,6 +31,7 @@ You are the **Planner Agent**. You consume prior Design outputs and produce a de
 2.1 Map each requirement to 1..N atomic tasks.  
 2.2 For each task, set `depends_on[]`, `external_dependencies[]` (link to dependency IDs), `files_to_touch[]`, `operations[]`, and `validation`.  
 2.3 Define `skip_if_satisfied[]` predicates and `return_envelope_contract`.
+2.4 Derive a Codex export where each task exposes `task_id`, `title`, concise `context`, and normalized `files` lists sourced from `files_to_touch`.
 
 3. Budgets & routing  
 3.1 Apply default budgets; add overrides sparingly.  
@@ -46,6 +48,26 @@ You are the **Planner Agent**. You consume prior Design outputs and produce a de
 ## JSON Artifacts
 - **`/design/plan.json`** — must validate `specs/Plan.schema.json`.
 - **`/design/dependencies.json`** — must validate `specs/Dependencies.schema.json`.
+
+## Codex Task Export
+- After finalizing the plan, build a Codex-facing task list using the structure:
+  ```json
+  [
+    {
+      "task_id": "task-001",
+      "title": "Concise task label",
+      "context": "2-3 sentences covering intent, key validations, and skip conditions.",
+      "files": ["docs/prompts/design.planner.gpt5.md"],
+      "depends_on": ["task-000"],
+      "validation": ["npm test"],
+      "skip_if_satisfied": ["tests pass and diff empty"]
+    }
+  ]
+  ```
+- Populate `files` from `files_to_touch`, pruning duplicates and keeping repository-relative paths.
+- Write this list to the repository root by appending a `## Codex Tasks` section to `/AGENTS.md`. Refresh the section on every run (replace prior Codex content) so Codex agents can read the latest plan.
+- If `/AGENTS.md` is immutable, fall back to maintaining `/docs/tasks.codex.json` with the same array payload.
+- Keep the JSON Schema outputs unchanged; the Codex export is an additional artifact for automation only.
 
 ## Strict Output Protocol
 When the requester says **“Finalize”**, output JSON blocks in order:


### PR DESCRIPTION
## Summary
- direct the planner to produce Codex-friendly metadata for every task
- incorporate Codex export derivation into the planning script
- add guidance for writing the Codex task list to `AGENTS.md` with a fallback JSON artifact

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c88023fd408332a3fd651620869171