### PR TITLE
Add research history schema and research search utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - `design/` - human design docs and machine artifacts
 - `cd/` - deployment plans
 - `docs/runs/` - audit snapshots of completed runs
+- `research/` - prior research notes and history logs (searchable via `scripts/query-research.mjs`)
 - `state/` - runtime state (gitignored)
 
 **AI Dev Tasks** is a schema-first, orchestrator-driven framework that turns a feature idea into deployed code through four phases:
@@ -797,8 +798,12 @@ These approvals are documented in both the human docs and the corresponding mach
 This section shows how to go from a raw feature idea to production using AI Dev Tasks.
 
 ### Step 1 — Start with an Idea
-- A human requester describes the feature or product idea.  
-- Example: *“Add email login with optional 2FA”*.  
+- A human requester describes the feature or product idea.
+- Example: *“Add email login with optional 2FA”*.
+- Before commissioning new analysis, run `node scripts/query-research.mjs "<query>"` to scan `/research/` for similar prior work.
+  - `--limit` (or `RESEARCH_SNIPPET_LIMIT`) tunes how many matching lines per file are shown.
+  - Add `--case-sensitive` for exact casing or `--json` to emit structured matches for automation.
+  - Capture refresh events in artifacts that validate against `specs/research-history.schema.json` so analysts know what’s current.
 
 ### Step 2 — Run the Design Phase
 - Open `/docs/planning/TEAM.chat.md` in ChatGPT.  

--- a/scripts/query-research.mjs
+++ b/scripts/query-research.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const researchDir = path.join(repoRoot, 'research');
+
+const DEFAULT_LIMIT = parseInt(process.env.RESEARCH_SNIPPET_LIMIT || '3', 10);
+const MAX_FILE_BYTES = parseInt(process.env.RESEARCH_MAX_FILE_BYTES || String(2 * 1024 * 1024), 10);
+
+const options = {
+  limit: Number.isFinite(DEFAULT_LIMIT) ? DEFAULT_LIMIT : 3,
+  caseSensitive: false,
+  json: false
+};
+
+const positional = [];
+const rawArgs = process.argv.slice(2);
+for (let i = 0; i < rawArgs.length; i += 1) {
+  const arg = rawArgs[i];
+  switch (arg) {
+    case '--limit':
+    case '-l': {
+      const value = rawArgs[i + 1];
+      if (value && !value.startsWith('--')) {
+        const parsed = parseInt(value, 10);
+        if (!Number.isNaN(parsed) && parsed > 0) {
+          options.limit = parsed;
+        }
+        i += 1;
+      }
+      break;
+    }
+    case '--case-sensitive':
+    case '--cs': {
+      options.caseSensitive = true;
+      break;
+    }
+    case '--json': {
+      options.json = true;
+      break;
+    }
+    default: {
+      positional.push(arg);
+      break;
+    }
+  }
+}
+
+const query = positional.join(' ').trim();
+
+if (!query) {
+  printUsage();
+  process.exit(1);
+}
+
+const needle = options.caseSensitive ? query : query.toLowerCase();
+
+async function listFiles(dir) {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+
+  const files = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await listFiles(fullPath);
+      files.push(...nested);
+    } else {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+async function scanFile(filePath) {
+  let stat;
+  try {
+    stat = await fs.stat(filePath);
+  } catch (err) {
+    if (err.code === 'ENOENT') return null;
+    throw err;
+  }
+
+  if (stat.size > MAX_FILE_BYTES) {
+    return {
+      path: path.relative(repoRoot, filePath),
+      matches: [],
+      skipped: true,
+      reason: `skipped (size ${(stat.size / (1024 * 1024)).toFixed(2)} MiB exceeds limit)`
+    };
+  }
+
+  let content;
+  try {
+    content = await fs.readFile(filePath, 'utf8');
+  } catch (err) {
+    return {
+      path: path.relative(repoRoot, filePath),
+      matches: [],
+      skipped: true,
+      reason: `skipped (unable to read as utf8: ${err.message})`
+    };
+  }
+
+  const matches = [];
+  const lines = content.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const haystack = options.caseSensitive ? line : line.toLowerCase();
+    if (haystack.includes(needle)) {
+      matches.push({
+        line: i + 1,
+        text: line.trim()
+      });
+    }
+  }
+
+  if (matches.length === 0) {
+    return null;
+  }
+
+  return {
+    path: path.relative(repoRoot, filePath),
+    matches,
+    skipped: false,
+    mtime: stat.mtime.toISOString()
+  };
+}
+
+async function main() {
+  const files = await listFiles(researchDir);
+  if (files.length === 0) {
+    console.error(`No research documents found under ${path.relative(repoRoot, researchDir) || '.'}`);
+    process.exit(1);
+  }
+
+  const results = [];
+  const skipped = [];
+  for (const file of files) {
+    const result = await scanFile(file);
+    if (!result) continue;
+    if (result.skipped) {
+      skipped.push(result);
+    } else {
+      results.push(result);
+    }
+  }
+
+  if (options.json) {
+    const payload = { query, options, results, skipped };
+    console.log(JSON.stringify(payload, null, 2));
+    process.exit(results.length > 0 ? 0 : 1);
+  }
+
+  if (results.length === 0) {
+    console.error(`No matches for "${query}" in ${path.relative(repoRoot, researchDir) || '.'}`);
+  } else {
+    for (const result of results) {
+      console.log(`${result.path} (last updated ${result.mtime})`);
+      const toShow = result.matches.slice(0, options.limit);
+      for (const match of toShow) {
+        console.log(`  L${match.line}: ${match.text}`);
+      }
+      if (result.matches.length > options.limit) {
+        const remaining = result.matches.length - options.limit;
+        console.log(`  ... ${remaining} more match${remaining === 1 ? '' : 'es'} in this file`);
+      }
+      console.log('');
+    }
+  }
+
+  if (skipped.length > 0) {
+    console.warn('Skipped files:');
+    for (const item of skipped) {
+      console.warn(`  ${item.path} — ${item.reason}`);
+    }
+  }
+
+  process.exit(results.length > 0 ? 0 : 1);
+}
+
+function printUsage() {
+  console.log(`Usage: node scripts/query-research.mjs <query> [--limit N] [--case-sensitive] [--json]\n\n` +
+    'Searches the /research/ directory for lines matching the query.\n' +
+    'Quote multi-word queries to keep them together.');
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/specs/research-history.schema.json
+++ b/specs/research-history.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "title": "Research History",
+  "description": "Historical log of research refresh events and their source data for a feature.",
+  "type": "object",
+  "required": ["feature_id", "entries"],
+  "properties": {
+    "feature_id": {
+      "type": "string",
+      "description": "Unique slug for the feature or product that the research applies to.",
+      "pattern": "^[a-z0-9][a-z0-9-]{1,63}$"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when this research history file was generated."
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Chronological list of research refresh events that analysts can reference before running new studies.",
+      "items": {
+        "type": "object",
+        "required": [
+          "recorded_at",
+          "data_source",
+          "valid_from"
+        ],
+        "properties": {
+          "recorded_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this research snapshot or finding was captured."
+          },
+          "data_source": {
+            "type": "object",
+            "required": ["name"],
+            "description": "Metadata about where the research insight originated.",
+            "properties": {
+              "type": {
+                "type": "string",
+                "description": "Classification of the data source.",
+                "enum": [
+                  "internal",
+                  "customer_interview",
+                  "market_report",
+                  "public_dataset",
+                  "vendor",
+                  "experiment",
+                  "other"
+                ]
+              },
+              "name": {
+                "type": "string",
+                "description": "Human-readable name of the data source, report, or interviewee group."
+              },
+              "uri": {
+                "type": "string",
+                "format": "uri",
+                "description": "Link to the source document or dataset when available."
+              },
+              "notes": {
+                "type": "string",
+                "description": "Additional context about how the data was collected or prepared."
+              }
+            },
+            "additionalProperties": false
+          },
+          "summary": {
+            "type": "string",
+            "description": "Key findings or themes captured during this research event."
+          },
+          "valid_from": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the findings became reliable or applicable."
+          },
+          "valid_until": {
+            "anyOf": [
+              { "type": "string", "format": "date-time" },
+              { "type": "null" }
+            ],
+            "description": "Optional timestamp that bounds when the findings stop being reliable. Leave null when still valid."
+          },
+          "confidence": {
+            "type": "string",
+            "enum": ["low", "medium", "high"],
+            "description": "Subjective confidence rating for this research snapshot."
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Searchable keywords that help analysts locate related research quickly."
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/specs/research-history.schema.json
+++ b/specs/research-history.schema.json
@@ -1,42 +1,42 @@
 {
   "$schema": "http://json-schema.org/draft/2020-12/schema",
-  "title": "Research History",
-  "description": "Historical log of research refresh events and their source data for a feature.",
+  "title": "Feature Research History",
+  "description": "Chronological record of when research for a feature was captured and how long each snapshot stays valid.",
   "type": "object",
-  "required": ["feature_id", "entries"],
+  "required": ["feature_slug", "entries"],
   "properties": {
-    "feature_id": {
+    "feature_slug": {
       "type": "string",
-      "description": "Unique slug for the feature or product that the research applies to.",
-      "pattern": "^[a-z0-9][a-z0-9-]{1,63}$"
+      "description": "Slug identifying the feature these research notes belong to.",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
     },
-    "generated_at": {
+    "updated_at": {
       "type": "string",
       "format": "date-time",
-      "description": "Timestamp when this research history file was generated."
+      "description": "Timestamp when this file was last refreshed."
     },
     "entries": {
       "type": "array",
       "minItems": 1,
-      "description": "Chronological list of research refresh events that analysts can reference before running new studies.",
+      "description": "Historical snapshots analysts can reference before running new research.",
       "items": {
         "type": "object",
-        "required": [
-          "recorded_at",
-          "data_source",
-          "valid_from"
-        ],
+        "required": ["captured_at", "data_source", "valid"],
         "properties": {
-          "recorded_at": {
+          "captured_at": {
             "type": "string",
             "format": "date-time",
-            "description": "When this research snapshot or finding was captured."
+            "description": "When this research snapshot was recorded."
           },
           "data_source": {
             "type": "object",
-            "required": ["name"],
-            "description": "Metadata about where the research insight originated.",
+            "required": ["label"],
+            "description": "Where the research insight originated.",
             "properties": {
+              "label": {
+                "type": "string",
+                "description": "Human-readable source name, report title, or interview group."
+              },
               "type": {
                 "type": "string",
                 "description": "Classification of the data source.",
@@ -45,54 +45,41 @@
                   "customer_interview",
                   "market_report",
                   "public_dataset",
-                  "vendor",
                   "experiment",
                   "other"
                 ]
               },
-              "name": {
-                "type": "string",
-                "description": "Human-readable name of the data source, report, or interviewee group."
-              },
               "uri": {
                 "type": "string",
                 "format": "uri",
-                "description": "Link to the source document or dataset when available."
-              },
-              "notes": {
-                "type": "string",
-                "description": "Additional context about how the data was collected or prepared."
+                "description": "Link to supporting material when available."
               }
             },
             "additionalProperties": false
           },
-          "summary": {
-            "type": "string",
-            "description": "Key findings or themes captured during this research event."
-          },
-          "valid_from": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Timestamp when the findings became reliable or applicable."
-          },
-          "valid_until": {
-            "anyOf": [
-              { "type": "string", "format": "date-time" },
-              { "type": "null" }
-            ],
-            "description": "Optional timestamp that bounds when the findings stop being reliable. Leave null when still valid."
-          },
-          "confidence": {
-            "type": "string",
-            "enum": ["low", "medium", "high"],
-            "description": "Subjective confidence rating for this research snapshot."
-          },
-          "tags": {
-            "type": "array",
-            "items": {
-              "type": "string"
+          "valid": {
+            "type": "object",
+            "required": ["from"],
+            "description": "Validity window for this research snapshot.",
+            "properties": {
+              "from": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp when the findings became reliable."
+              },
+              "until": {
+                "anyOf": [
+                  { "type": "string", "format": "date-time" },
+                  { "type": "null" }
+                ],
+                "description": "Optional timestamp when the findings expire. Use null while still valid."
+              }
             },
-            "description": "Searchable keywords that help analysts locate related research quickly."
+            "additionalProperties": false
+          },
+          "notes": {
+            "type": "string",
+            "description": "Short summary or pointers for future analysts."
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
## Summary
- add a research history schema to capture feature slugs, sources, and validity windows
- introduce a query script that searches `/research/` for matching lines with optional JSON output
- document how to use the research search helper in the README and establish a tracked `research/` directory

## Testing
- `node scripts/query-research.mjs churn`


------
https://chatgpt.com/codex/tasks/task_e_68c88028f9408332ae4f1816bc4b5806