### PR TITLE
Make research tooling tolerant of empty repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - `design/` - human design docs and machine artifacts
 - `cd/` - deployment plans
 - `docs/runs/` - audit snapshots of completed runs
+- `research/` - prior research notes and history logs (searchable via `scripts/query-research.mjs`)
 - `state/` - runtime state (gitignored)
 
 **AI Dev Tasks** is a schema-first, orchestrator-driven framework that turns a feature idea into deployed code through four phases:
@@ -797,8 +798,13 @@ These approvals are documented in both the human docs and the corresponding mach
 This section shows how to go from a raw feature idea to production using AI Dev Tasks.
 
 ### Step 1 — Start with an Idea
-- A human requester describes the feature or product idea.  
-- Example: *“Add email login with optional 2FA”*.  
+- A human requester describes the feature or product idea.
+- Example: *“Add email login with optional 2FA”*.
+- Before commissioning new analysis, run `node scripts/query-research.mjs "<query>"` to scan `/research/` for similar prior work.
+  - The helper prints friendly warnings (and still exits 0) when there are no documents or matches yet, so new repos don’t break quickstarts.
+  - `--limit` (or `RESEARCH_SNIPPET_LIMIT`) tunes how many matching lines per file are shown.
+  - Add `--case-sensitive` for exact casing or `--json` to emit structured matches for automation.
+  - Capture refresh events in artifacts that validate against `specs/research-history.schema.json` so analysts know what’s current.
 
 ### Step 2 — Run the Design Phase
 - Open `/docs/planning/TEAM.chat.md` in ChatGPT.  

--- a/scripts/query-research.mjs
+++ b/scripts/query-research.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const researchDir = path.join(repoRoot, 'research');
+
+const rawArgs = process.argv.slice(2);
+
+function usage() {
+  console.log(`Usage: node scripts/query-research.mjs <query> [--limit N] [--case-sensitive] [--json]\n\n` +
+    'Search the /research/ directory for lines that mention the query.');
+}
+
+let limit = parseInt(process.env.RESEARCH_SNIPPET_LIMIT || '3', 10);
+if (!Number.isFinite(limit) || limit <= 0) limit = 3;
+let caseSensitive = false;
+let outputJson = false;
+
+const terms = [];
+for (let i = 0; i < rawArgs.length; i += 1) {
+  const arg = rawArgs[i];
+  switch (arg) {
+    case '--help':
+    case '-h':
+      usage();
+      process.exit(0);
+      break;
+    case '--limit':
+    case '-l': {
+      const value = rawArgs[i + 1];
+      if (!value || value.startsWith('-')) {
+        console.error('Missing value after --limit');
+        process.exit(1);
+      }
+      const parsed = parseInt(value, 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        console.error('Limit must be a positive integer.');
+        process.exit(1);
+      }
+      limit = parsed;
+      i += 1;
+      break;
+    }
+    case '--case-sensitive':
+    case '--cs':
+      caseSensitive = true;
+      break;
+    case '--json':
+      outputJson = true;
+      break;
+    default:
+      terms.push(arg);
+  }
+}
+
+const query = terms.join(' ').trim();
+if (!query) {
+  usage();
+  process.exit(1);
+}
+
+const needle = caseSensitive ? query : query.toLowerCase();
+
+async function listFiles(dir) {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return [];
+    }
+    throw err;
+  }
+
+  const files = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await listFiles(full);
+      files.push(...nested);
+    } else {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+async function scanFile(filePath) {
+  let stat;
+  try {
+    stat = await fs.stat(filePath);
+  } catch (err) {
+    if (err.code === 'ENOENT') return { skipped: true, reason: 'file removed before scanning' };
+    throw err;
+  }
+
+  if (stat.size > (2 * 1024 * 1024)) {
+    return {
+      skipped: true,
+      reason: `skipped (size ${(stat.size / (1024 * 1024)).toFixed(2)} MiB exceeds limit)`
+    };
+  }
+
+  let content;
+  try {
+    content = await fs.readFile(filePath, 'utf8');
+  } catch (err) {
+    return { skipped: true, reason: `skipped (unable to read as utf8: ${err.message})` };
+  }
+
+  const matches = [];
+  const lines = content.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const haystack = caseSensitive ? line : line.toLowerCase();
+    if (haystack.includes(needle)) {
+      matches.push({ line: i + 1, text: line.trim() });
+    }
+  }
+
+  if (matches.length === 0) {
+    return null;
+  }
+
+  return {
+    path: path.relative(repoRoot, filePath),
+    matches,
+    mtime: stat.mtime.toISOString(),
+    skipped: false
+  };
+}
+
+async function main() {
+  const files = await listFiles(researchDir);
+  const results = [];
+  const skipped = [];
+
+  if (files.length === 0) {
+    if (outputJson) {
+      console.log(JSON.stringify({
+        query,
+        options: { limit, caseSensitive },
+        results,
+        skipped,
+        warning: 'No research documents found under /research/.'
+      }, null, 2));
+    } else {
+      console.warn('No research documents found under /research/.');
+    }
+    return 0;
+  }
+
+  for (const file of files) {
+    const result = await scanFile(file);
+    if (!result) continue;
+    if (result.skipped) {
+      skipped.push({ path: path.relative(repoRoot, file), reason: result.reason });
+    } else {
+      results.push(result);
+    }
+  }
+
+  if (outputJson) {
+    console.log(JSON.stringify({ query, options: { limit, caseSensitive }, results, skipped }, null, 2));
+  } else if (results.length === 0) {
+    console.warn(`No matches for "${query}" in /research/.`);
+  } else {
+    for (const result of results) {
+      console.log(`${result.path} (last updated ${result.mtime})`);
+      const shown = result.matches.slice(0, limit);
+      for (const match of shown) {
+        console.log(`  L${match.line}: ${match.text}`);
+      }
+      if (result.matches.length > limit) {
+        const remaining = result.matches.length - limit;
+        console.log(`  ... ${remaining} more match${remaining === 1 ? '' : 'es'} in this file`);
+      }
+      console.log('');
+    }
+  }
+
+  if (skipped.length > 0) {
+    console.warn('Skipped files:');
+    for (const item of skipped) {
+      console.warn(`  ${item.path} — ${item.reason}`);
+    }
+  }
+
+  return 0;
+}
+
+main()
+  .then((code) => {
+    process.exit(code);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+

--- a/specs/research-history.schema.json
+++ b/specs/research-history.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "title": "Feature Research History",
+  "description": "Chronological record of when research for a feature was captured and how long each snapshot stays valid.",
+  "type": "object",
+  "required": ["feature_slug", "entries"],
+  "properties": {
+    "feature_slug": {
+      "type": "string",
+      "description": "Slug identifying the feature these research notes belong to.",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when this file was last refreshed."
+    },
+    "entries": {
+      "type": "array",
+      "description": "Historical snapshots analysts can reference before running new research.",
+      "items": {
+        "type": "object",
+        "required": ["captured_at", "data_source", "valid"],
+        "properties": {
+          "captured_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this research snapshot was recorded."
+          },
+          "data_source": {
+            "type": "object",
+            "required": ["label"],
+            "description": "Where the research insight originated.",
+            "properties": {
+              "label": {
+                "type": "string",
+                "description": "Human-readable source name, report title, or interview group."
+              },
+              "type": {
+                "type": "string",
+                "description": "Classification of the data source.",
+                "enum": [
+                  "internal",
+                  "customer_interview",
+                  "market_report",
+                  "public_dataset",
+                  "experiment",
+                  "other"
+                ]
+              },
+              "uri": {
+                "type": "string",
+                "format": "uri",
+                "description": "Link to supporting material when available."
+              }
+            },
+            "additionalProperties": false
+          },
+          "valid": {
+            "type": "object",
+            "required": ["from"],
+            "description": "Validity window for this research snapshot.",
+            "properties": {
+              "from": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp when the findings became reliable."
+              },
+              "until": {
+                "anyOf": [
+                  { "type": "string", "format": "date-time" },
+                  { "type": "null" }
+                ],
+                "description": "Optional timestamp when the findings expire. Use null while still valid."
+              }
+            },
+            "additionalProperties": false
+          },
+          "notes": {
+            "type": "string",
+            "description": "Short summary or pointers for future analysts."
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- adjust the research query helper to warn (but exit successfully) when /research has no docs or matches and streamline its exit handling
- relax the research-history schema so new files can start with zero entries
- document the helper’s new behavior in the quickstart guide

## Testing
- `node scripts/query-research.mjs churn`
- `node scripts/query-research.mjs churn --json`


------
https://chatgpt.com/codex/tasks/task_e_68c88028f9408332ae4f1816bc4b5806