### PR TITLE
Add research history schema and lookup tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ records. When starting a new investigation, consult the existing folders first, 
 work, and only reuse insights in design docs after they are distilled into stakeholder-ready prose with citations back to the
 raw material.
 
+To make those sweeps discoverable, maintain lightweight history indexes alongside the raw transcripts. Store them as `*.history.json` files (for example `/research/history/onboarding.history.json`) and validate each document against [`specs/research-history.schema.json`](specs/research-history.schema.json). Every entry captures the `feature_slug`, when the source was collected, where to find it (`source.path` or `source.url`), and a `validity` window so agents know when the data becomes stale. Use `summary`, `topics`, and `tags` to speed up scanning, and update `supersedes` when a new capture replaces an older one.
+
+Agents can query the accumulated history before launching a new sweep:
+
+```sh
+node scripts/query-research.mjs --feature onboarding --on 2024-06-01T00:00:00Z
+```
+
+The script walks `/research/` for `*.history.json` files, filters by feature/date, and prints the matching entries as JSON so downstream tasks can link directly to reusable findings. Combine `--from` / `--to` to narrow by capture date or omit all filters to list the entire archive.
+
 ### Product Requirements & Planning Flow
 
 Once discovery is saturated, the **Product Manager agent** (operating through the Product Manager Tool) orchestrates PRD

--- a/scripts/query-research.mjs
+++ b/scripts/query-research.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const researchRoot = path.join(repoRoot, 'research');
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args.help) {
+  printUsage();
+  process.exit(0);
+}
+
+let onTime;
+let fromTime;
+let toTime;
+
+try {
+  onTime = parseDateArg(args.on, '--on');
+  fromTime = parseDateArg(args.from, '--from');
+  toTime = parseDateArg(args.to, '--to');
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}
+
+const featureFilter = args.feature;
+
+async function collectEntries() {
+  const matches = [];
+  await walk(researchRoot, async filePath => {
+    const relPath = path.relative(repoRoot, filePath);
+    let raw;
+    try {
+      raw = await fs.readFile(filePath, 'utf8');
+    } catch (err) {
+      console.warn(`Skipping ${relPath}: unable to read file (${err.message})`);
+      return;
+    }
+
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch (err) {
+      console.warn(`Skipping ${relPath}: invalid JSON (${err.message})`);
+      return;
+    }
+
+    if (!data || typeof data !== 'object' || !Array.isArray(data.entries)) {
+      return;
+    }
+
+    for (const entry of data.entries) {
+      if (!entry || typeof entry !== 'object') {
+        continue;
+      }
+
+      const featureSlug = entry.feature_slug || entry.feature_id || entry.feature;
+      if (featureFilter && featureSlug !== featureFilter) {
+        continue;
+      }
+
+      const capturedTime = parseTimestamp(entry.captured_at) ?? parseTimestamp(entry.timestamp) ?? parseTimestamp(entry.recorded_at) ?? parseTimestamp(entry.validity?.start);
+      if (fromTime !== null && (capturedTime === null || capturedTime < fromTime)) {
+        continue;
+      }
+      if (toTime !== null && (capturedTime === null || capturedTime > toTime)) {
+        continue;
+      }
+
+      if (onTime !== null) {
+        const validity = entry.validity && typeof entry.validity === 'object' ? entry.validity : {};
+        const startTime = parseTimestamp(validity.start) ?? capturedTime;
+        const endTime = parseTimestamp(validity.end ?? validity.until ?? entry.valid_until);
+        if (startTime === null || onTime < startTime) {
+          continue;
+        }
+        if (endTime !== null && onTime > endTime) {
+          continue;
+        }
+      }
+
+      const sanitized = JSON.parse(JSON.stringify(entry));
+      sanitized.source_file = relPath;
+      if (!sanitized.feature_slug && featureSlug) {
+        sanitized.feature_slug = featureSlug;
+      }
+      matches.push(sanitized);
+    }
+  });
+
+  matches.sort((a, b) => {
+    const aTime = parseTimestamp(a.captured_at) ?? parseTimestamp(a.validity?.start) ?? 0;
+    const bTime = parseTimestamp(b.captured_at) ?? parseTimestamp(b.validity?.start) ?? 0;
+    return bTime - aTime;
+  });
+
+  return matches;
+}
+
+collectEntries()
+  .then(results => {
+    console.log(JSON.stringify(results, null, 2));
+  })
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+
+async function walk(dir, onFile) {
+  let dirents;
+  try {
+    dirents = await fs.readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return;
+    }
+    throw err;
+  }
+
+  for (const dirent of dirents) {
+    const fullPath = path.join(dir, dirent.name);
+    if (dirent.isDirectory()) {
+      await walk(fullPath, onFile);
+    } else if (dirent.isFile() && dirent.name.endsWith('.history.json')) {
+      await onFile(fullPath);
+    }
+  }
+}
+
+function parseArgs(argv) {
+  const parsed = { _: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--help' || token === '-h') {
+      parsed.help = true;
+      continue;
+    }
+    if (token === '--feature' || token === '-f') {
+      parsed.feature = requireValue(argv, ++i, token);
+      continue;
+    }
+    if (token === '--on') {
+      parsed.on = requireValue(argv, ++i, token);
+      continue;
+    }
+    if (token === '--from') {
+      parsed.from = requireValue(argv, ++i, token);
+      continue;
+    }
+    if (token === '--to') {
+      parsed.to = requireValue(argv, ++i, token);
+      continue;
+    }
+    if (token.startsWith('-')) {
+      throw new Error(`Unknown option: ${token}`);
+    }
+    parsed._.push(token);
+  }
+  return parsed;
+}
+
+function requireValue(argv, index, flag) {
+  if (index >= argv.length || argv[index].startsWith('-')) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return argv[index];
+}
+
+function parseDateArg(value, flag) {
+  if (!value) {
+    return null;
+  }
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    throw new Error(`Invalid date for ${flag}: ${value}. Use an ISO-8601 string (e.g. 2024-06-01T12:00:00Z).`);
+  }
+  return timestamp;
+}
+
+function parseTimestamp(value) {
+  if (!value || typeof value !== 'string') {
+    return null;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function printUsage() {
+  console.log(`Usage: node scripts/query-research.mjs [options]\n\n` +
+    `Scans research history files (*.history.json) under /research and prints matching entries as JSON.\n\n` +
+    `Options:\n` +
+    `  -h, --help           Show this message and exit.\n` +
+    `  -f, --feature <slug> Limit results to a specific feature slug.\n` +
+    `      --on <timestamp> Return entries whose validity window covers the given ISO-8601 timestamp.\n` +
+    `      --from <timestamp> Limit to entries captured on or after the timestamp.\n` +
+    `      --to <timestamp>   Limit to entries captured on or before the timestamp.\n` +
+    `\nExamples:\n` +
+    `  node scripts/query-research.mjs --feature onboarding --on 2024-06-01T00:00:00Z\n` +
+    `  node scripts/query-research.mjs --from 2024-01-01 --to 2024-03-31\n`);
+}

--- a/specs/research-history.schema.json
+++ b/specs/research-history.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "title": "Research History Index",
+  "description": "Catalog of previously captured research artifacts with provenance and validity windows for reuse across runs.",
+  "type": "object",
+  "required": [
+    "generated_at",
+    "entries"
+  ],
+  "properties": {
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp indicating when this index was last regenerated."
+    },
+    "notes": {
+      "type": "string",
+      "description": "Optional instructions for how to interpret or update this history index."
+    },
+    "entries": {
+      "type": "array",
+      "description": "Individual research captures with their provenance and validity windows.",
+      "items": {
+        "type": "object",
+        "required": [
+          "feature_slug",
+          "captured_at",
+          "source",
+          "validity"
+        ],
+        "properties": {
+          "feature_slug": {
+            "type": "string",
+            "description": "Slug identifying the feature or initiative the research supports.",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,63}$"
+          },
+          "captured_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the underlying research artifact was created."
+          },
+          "source": {
+            "type": "object",
+            "description": "Pointer to the underlying research artifact.",
+            "required": [
+              "path"
+            ],
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Repository-relative path to the research artifact."
+              },
+              "type": {
+                "type": "string",
+                "description": "Classification of the referenced artifact.",
+                "enum": [
+                  "raw",
+                  "summary",
+                  "analysis",
+                  "external",
+                  "other"
+                ]
+              },
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "Resolvable link to the artifact when it lives outside this repository."
+              },
+              "hash": {
+                "type": "string",
+                "description": "Optional checksum of the referenced artifact for integrity checks."
+              },
+              "notes": {
+                "type": "string",
+                "description": "Additional context on how to retrieve or interpret the source."
+              }
+            },
+            "additionalProperties": false
+          },
+          "validity": {
+            "type": "object",
+            "description": "Window describing how long the research can be relied upon before refreshing.",
+            "required": [
+              "start"
+            ],
+            "properties": {
+              "start": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp when the research became valid for reuse."
+              },
+              "end": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Timestamp after which the research should be considered stale."
+              },
+              "confidence": {
+                "type": "string",
+                "description": "Optional qualitative confidence rating in the validity window.",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "refresh_conditions": {
+                "type": "string",
+                "description": "Signals or events that should trigger a new research sweep."
+              }
+            },
+            "additionalProperties": false
+          },
+          "summary": {
+            "type": "string",
+            "description": "Short description of the findings contained in the research artifact."
+          },
+          "topics": {
+            "type": "array",
+            "description": "Key subjects covered by the research artifact.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "description": "Searchable keywords or labels assigned to this capture.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "related_features": {
+            "type": "array",
+            "description": "Other feature slugs that can reuse this research.",
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z0-9][a-z0-9-]{1,63}$"
+            }
+          },
+          "supersedes": {
+            "type": "array",
+            "description": "Paths or identifiers of older research artifacts replaced by this entry.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "notes": {
+            "type": "string",
+            "description": "Operational notes for future analysts about this capture."
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add a research history schema that captures feature slugs, provenance, and validity windows for reuse
- implement a query script that scans `*.history.json` records under `/research` with feature/date filters
- document how to author the history files and invoke the lookup script from the README

## Testing
- `node scripts/query-research.mjs --help`
- `node scripts/query-research.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68c88f2490b48332900c1a7976d8c972