### PR TITLE
Add documentation for n8n workflow templates

### DIFF
--- a/docs/workflows/deployment-n8n.md
+++ b/docs/workflows/deployment-n8n.md
@@ -1,5 +1,7 @@
 # n8n Deployment Workflow
 
+Canonical JSON template: [`templates/deployment-n8n.json`](templates/deployment-n8n.json)
+
 ## Flow Overview
 ```mermaid
 flowchart LR

--- a/docs/workflows/design-n8n.md
+++ b/docs/workflows/design-n8n.md
@@ -1,5 +1,7 @@
 # n8n Design Workflow
 
+Canonical JSON template: [`templates/design-n8n.json`](templates/design-n8n.json)
+
 ## Flow Overview
 ```mermaid
 flowchart LR

--- a/docs/workflows/integration-n8n.md
+++ b/docs/workflows/integration-n8n.md
@@ -1,5 +1,7 @@
 # n8n Integration Workflow
 
+Canonical JSON template: [`templates/integration-n8n.json`](templates/integration-n8n.json)
+
 ## Flow Overview
 ```mermaid
 flowchart LR

--- a/docs/workflows/templates/README.md
+++ b/docs/workflows/templates/README.md
@@ -1,0 +1,20 @@
+# n8n Workflow Templates
+
+This directory stores the finalized n8n workflow exports that accompany the markdown guides in `docs/workflows/`.
+Each automation described in those guides should have a matching JSON definition checked in here once the flow has
+been validated in n8n.
+
+## Export & versioning conventions
+- Export flows from n8n using **Download > File** so the JSON matches what can be re-imported without modification.
+- Keep the **Include credentials** option disabled to prevent secrets from entering version control. Instead, document
+  credential requirements in the workflow markdown files.
+- Name the canonical file for each workflow `templates/<workflow>-n8n.json` and update the referenced markdown link whenever
+  the flow changes.
+- Preserve prior revisions by suffixing the filename with a semantic version or date stamp (e.g.,
+  `design-n8n.v1.1.0.json` or `deployment-n8n.2024-04-18.json`) before committing the new canonical file. This keeps the
+  history auditable while maintaining a stable pointer for the current release.
+
+## Expected templates
+- Design workflow JSON: `templates/design-n8n.json`
+- Integration workflow JSON: `templates/integration-n8n.json`
+- Deployment workflow JSON: `templates/deployment-n8n.json`


### PR DESCRIPTION
## Summary
- create a templates directory for finalized n8n workflow exports and document naming conventions
- note canonical JSON template links from the design, integration, and deployment workflow guides

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c969b2cd3c8332b1be59db5358545e